### PR TITLE
Add vim persistent undo files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ Scripts/
 *.swo
 tags
 ctags.tmp
+[._]*.un~
 
 # vagrant stuff
 virtualization/vagrant/setup_done


### PR DESCRIPTION
If we have the following vim config:
`set undofile`
Then files matching `[._]*.un~` will be created.

Ignore these the git repo.

Reference: https://jovicailic.org/2017/04/vim-persistent-undo/